### PR TITLE
Replaced a typo with rockchip_pmu_set_idle_request

### DIFF
--- a/vcodec/Kconfig
+++ b/vcodec/Kconfig
@@ -4,6 +4,7 @@ menu "VCODEC"
 config RK_VCODEC
 	tristate "VCODEC (VPU HEVC) service driver in kernel"
 	depends on ARCH_ROCKCHIP
+	depends on ROCKCHIP_PM_DOMAINS
 	default n
 
 endmenu

--- a/vcodec/vcodec_service.c
+++ b/vcodec/vcodec_service.c
@@ -616,7 +616,7 @@ static int vpu_get_clk(struct vpu_service_info *pservice)
 #endif
 }
 
-extern int rockchip_pmu_idle_request(struct device *dev, bool idle);
+extern int rockchip_pmu_set_idle_request(struct device *dev, bool idle);
 static void _vpu_reset(struct vpu_subdev_data *data)
 {
 	struct vpu_service_info *pservice = data->pservice;
@@ -632,7 +632,7 @@ static void _vpu_reset(struct vpu_subdev_data *data)
 #ifdef CONFIG_RESET_CONTROLLER
 	dev_info(pservice->dev, "for 3288/3368...");
 	if (of_machine_is_compatible("rockchip,rk3288"))
-		rockchip_pmu_idle_request(pservice->dev, true);
+		rockchip_pmu_set_idle_request(pservice->dev, true);
 	if (pservice->rst_a && pservice->rst_h) {
 		dev_info(pservice->dev, "vpu reset in\n");
 
@@ -654,7 +654,7 @@ static void _vpu_reset(struct vpu_subdev_data *data)
 		reset_control_deassert(pservice->rst_v);
 	}
 	if (of_machine_is_compatible("rockchip,rk3288"))
-		rockchip_pmu_idle_request(pservice->dev, false);
+		rockchip_pmu_set_idle_request(pservice->dev, false);
 #endif
 }
 


### PR DESCRIPTION
Thanks to DuckDuckGo for the suggestion when I was searching the
mistyped symbol.

Well, I think it's this one. It almost has the same name AND the same
signature. However, I currently do not understand what the code does so
I might be wrong.
The module compiles and loads fine with this correction. However, I do
not know if it runs fine.

This *still* needs a patched mainline kernel in order that exports this symbol.
The appropriate patch is available here:
https://github.com/Miouyouyou/MyyQi/blob/a1e040fb36bf4b34a926464ef062c1bd4fe7faaf/patches/kernel/v4.10-rc4/0013-Export-rockchip_pmu_set_idle_request-for-out-of-tree.patch

Signed-off-by: Myy <myy@miouyouyou.fr>